### PR TITLE
Add graphlet baseline and training pipeline

### DIFF
--- a/.reports/report.md
+++ b/.reports/report.md
@@ -1,0 +1,18 @@
+# Graphlet Model Baseline
+
+This report summarizes the added baseline for protein-protein interaction prediction based on graphlet graphs.
+
+## Overview
+- Each protein is represented by a graph whose nodes are structural graphlets.
+- Node features encode amino-acid composition of the graphlet (20 dims).
+- A `GraphletLinkPredictor` learns embeddings using two GCN layers and predicts interactions via an MLP on element-wise combinations of protein embeddings.
+- Training and evaluation utilities are provided to run on a single GPU.
+
+## Usage
+Run the training script after preparing graphlet files in `data/external/graphlets` and cleaned splits in `data/processed`:
+
+```bash
+python scripts/train_graphlet_model.py
+```
+
+The model checkpoints are saved under `models/`.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ The PPI dataset from Gold-standard PPI splits (Bernett et al. 2024) has the foll
 * No direct data leakage between splits
 * Minimized sequence similarity w.r.t. length-normalized bitscores between training, validation, test
 * Redundancy-reduction with CD-HIT (no sequence similarity >40% between proteins in each split)
+
+## Graphlet baseline
+
+Graphlet graphs for each protein should be placed under `data/external/graphlets`. Use the training script to fit the baseline GCN model:
+
+```bash
+python scripts/train_graphlet_model.py
+```
+
+A summary of the model is provided in `.reports/report.md`.

--- a/gppinlib/graphlet_data.py
+++ b/gppinlib/graphlet_data.py
@@ -1,0 +1,53 @@
+# ruff: noqa: E402
+# %%
+"""Graphlet data loading utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from torch.utils.data import Dataset
+from torch_geometric.data import Batch, Data
+
+from .paths import GRAPHLET_DIR
+
+
+class GraphletLoader:
+    """Load per-protein graphlet graphs from disk."""
+
+    def __init__(self, graph_dir: Path = GRAPHLET_DIR):
+        self.graph_dir = Path(graph_dir)
+
+    def __call__(self, pid: str) -> Data:
+        fp = self.graph_dir / f"{pid}.pt"
+        if not fp.exists():
+            raise FileNotFoundError(f"Graphlet file missing: {fp}")
+        return torch.load(fp)
+
+
+class GraphletPairDataset(Dataset):
+    """Return pairs of graphlet graphs for link prediction."""
+
+    def __init__(self, dataframe, graph_dir: Path = GRAPHLET_DIR):
+        self.df = dataframe.reset_index(drop=True)
+        self.loader = GraphletLoader(graph_dir)
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.df)
+
+    def __getitem__(self, idx: int) -> Tuple[Data, Data, float]:
+        row = self.df.iloc[idx]
+        g_a = self.loader(row.InteractorA)
+        g_b = self.loader(row.InteractorB)
+        return g_a, g_b, float(row.Label)
+
+
+def collate_graphlet_pairs(batch):
+    g1, g2, y = zip(*batch)
+    return (
+        Batch.from_data_list(g1),
+        Batch.from_data_list(g2),
+        torch.tensor(y, dtype=torch.float32),
+    )

--- a/gppinlib/graphlet_model.py
+++ b/gppinlib/graphlet_model.py
@@ -1,0 +1,82 @@
+# ruff: noqa: E402
+# %%
+from __future__ import annotations
+"""Graph neural network for graphlet-based protein representation."""
+
+from typing import Tuple
+from sklearn.metrics import balanced_accuracy_score, roc_auc_score
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch_geometric.nn import GCNConv, global_mean_pool
+
+
+class GraphletEncoder(nn.Module):
+    def __init__(self, in_dim: int, hidden_dim: int, dropout: float = 0.2):
+        super().__init__()
+        self.conv1 = GCNConv(in_dim, hidden_dim)
+        self.conv2 = GCNConv(hidden_dim, hidden_dim)
+        self.dropout = dropout
+
+    def forward(self, data):
+        x = F.relu(self.conv1(data.x, data.edge_index))
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = F.relu(self.conv2(x, data.edge_index))
+        return global_mean_pool(x, data.batch)
+
+
+class GraphletLinkPredictor(nn.Module):
+    def __init__(self, in_dim: int, hidden_dim: int):
+        super().__init__()
+        self.encoder = GraphletEncoder(in_dim, hidden_dim)
+        self.classifier = nn.Sequential(
+            nn.Linear(hidden_dim * 2, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, g1, g2):
+        h1 = self.encoder(g1)
+        h2 = self.encoder(g2)
+        pair = torch.cat([h1 * h2, torch.abs(h1 - h2)], dim=1)
+        return self.classifier(pair).squeeze(-1)
+
+
+# --------------------------------------------------
+# Training helpers
+# --------------------------------------------------
+
+def train_epoch(model, loader, optimizer, device) -> float:
+    model.train()
+    total_loss = 0.0
+    for g1, g2, y in loader:
+        g1, g2, y = g1.to(device), g2.to(device), y.to(device)
+        optimizer.zero_grad()
+        out = model(g1, g2)
+        loss = F.binary_cross_entropy_with_logits(out, y)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item() * y.size(0)
+    return total_loss / len(loader.dataset)
+
+
+
+@torch.no_grad()
+def evaluate(model, loader, device) -> Tuple[float, float, float]:
+    model.eval()
+    probs, targets = [], []
+    total_loss = 0.0
+    for g1, g2, y in loader:
+        g1, g2 = g1.to(device), g2.to(device)
+        out = torch.sigmoid(model(g1, g2))
+        loss = F.binary_cross_entropy(out, y.to(device))
+        total_loss += loss.item() * y.size(0)
+        probs.append(out.cpu())
+        targets.append(y)
+    prob = torch.cat(probs)
+    y_true = torch.cat(targets)
+    pred = (prob >= 0.5).float()
+    acc = balanced_accuracy_score(y_true, pred)
+    auc = roc_auc_score(y_true, prob)
+    return acc, auc, total_loss / len(loader.dataset)

--- a/gppinlib/paths.py
+++ b/gppinlib/paths.py
@@ -14,6 +14,7 @@ EXTERNAL_DATA_DIR = DATA_DIR / "external"
 INTERIM_DATA_DIR = DATA_DIR / "interim"
 PROCESSED_DATA_DIR = DATA_DIR / "processed"
 EMB_PER_PROTEIN_DIR = INTERIM_DATA_DIR / "per_protein"
+GRAPHLET_DIR = EXTERNAL_DATA_DIR / "graphlets"
 EMB_PER_RESIDUE_DIR = INTERIM_DATA_DIR / "per_residue"
 MODELS_DIR = PROJ_ROOT / "models"
 LOG_DIR = PROJ_ROOT / "logs"
@@ -32,6 +33,7 @@ for d in [
     INTERIM_DATA_DIR,
     PROCESSED_DATA_DIR,
     MODELS_DIR,
+    GRAPHLET_DIR,
     LOG_DIR,
 ]:
     d.mkdir(parents=True, exist_ok=True)

--- a/scripts/train_graphlet_model.py
+++ b/scripts/train_graphlet_model.py
@@ -1,0 +1,40 @@
+# ruff: noqa: E402
+# %%
+"""Training entry point for graphlet-based PPI prediction."""
+
+
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+
+from gppinlib.graphlet_data import GraphletPairDataset, collate_graphlet_pairs
+from gppinlib.graphlet_model import GraphletLinkPredictor, train_epoch, evaluate
+from gppinlib.paths import GRAPHLET_DIR, PROCESSED_DATA_DIR, MODELS_DIR
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_df = pd.read_csv(PROCESSED_DATA_DIR / "train.csv")
+    val_df = pd.read_csv(PROCESSED_DATA_DIR / "val.csv")
+
+    train_ds = GraphletPairDataset(train_df, GRAPHLET_DIR)
+    val_ds = GraphletPairDataset(val_df, GRAPHLET_DIR)
+
+    train_dl = DataLoader(train_ds, batch_size=32, shuffle=True, collate_fn=collate_graphlet_pairs)
+    val_dl = DataLoader(val_ds, batch_size=32, collate_fn=collate_graphlet_pairs)
+
+    model = GraphletLinkPredictor(in_dim=20, hidden_dim=64).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    for epoch in range(10):
+        loss = train_epoch(model, train_dl, optimizer, device)
+        acc, auc, val_loss = evaluate(model, val_dl, device)
+        print(f"Epoch {epoch:02d} | train_loss {loss:.4f} | val_loss {val_loss:.4f} | val_acc {acc:.3f} | val_auc {auc:.3f}")
+
+    MODELS_DIR.mkdir(exist_ok=True, parents=True)
+    torch.save(model.state_dict(), MODELS_DIR / "graphlet_model.pt")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add graphlet dataset loader and pair collate
- implement GCN-based GraphletLinkPredictor
- extend paths with `GRAPHLET_DIR`
- create training script with GPU support
- document usage in README and `.reports`

## Testing
- `PYENV_VERSION=3.10.17 pytest -q`
- `PYENV_VERSION=3.10.17 ruff check gppinlib/graphlet_data.py gppinlib/graphlet_model.py scripts/train_graphlet_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ebbc91608324add7044c576c2959